### PR TITLE
Django 2.0.13 Fix

### DIFF
--- a/pinax/notifications_backends/models.py
+++ b/pinax/notifications_backends/models.py
@@ -8,7 +8,7 @@ from django.utils import timezone
 from django.db import models
 from django.utils.translation import ugettext_lazy as _
 from django.utils.translation import get_language, activate
-from django.core.urlresolvers import reverse
+from django.urls import reverse
 
 from .managers import NoticeManager
 


### PR DESCRIPTION
Djnago.core.urlresolvers was removed and had to be replaced with django.urls